### PR TITLE
kapp and vendir arm64 support

### DIFF
--- a/kapp.rb
+++ b/kapp.rb
@@ -3,15 +3,20 @@ class Kapp < Formula
   homepage "https://get-kapp.io"
   version "v0.37.0"
 
-  if OS.mac?
+  on_macos do
     url "https://github.com/k14s/kapp/releases/download/v0.37.0/kapp-darwin-amd64"
     sha256 "da6411b79c66138cd7437beb268675edf2df3c0a4a8be07fb140dd4ebde758c1"
-  elsif OS.linux?
-    url "https://github.com/k14s/kapp/releases/download/v0.37.0/kapp-linux-amd64"
-    sha256 "f845233deb6c87feac7c82d9b3f5e03ced9a4672abb1a14d4e5b74fe53bc4538"
   end
 
-  depends_on :arch => :x86_64
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/k14s/kapp/releases/download/v0.37.0/kapp-linux-arm64"
+      sha256 "d4ae2a9f8fc67f19ee4327e7ef34c274fbe50f2f1770b9bdab6446ad871589f2"
+    else
+      url "https://github.com/k14s/kapp/releases/download/v0.37.0/kapp-linux-amd64"
+      sha256 "f845233deb6c87feac7c82d9b3f5e03ced9a4672abb1a14d4e5b74fe53bc4538"
+    end
+  end
 
   def install
     bin.install stable.url.split("/")[-1] => "kapp"

--- a/vendir.rb
+++ b/vendir.rb
@@ -3,15 +3,20 @@ class Vendir < Formula
   homepage "https://carvel.dev/vendir"
   version "v0.19.0"
 
-  if OS.mac?
+  on_macos do
     url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.19.0/vendir-darwin-amd64"
     sha256 "81c11620d97ff05ab37036bb1761ef0faff403a3380ea87a1152ec36508e698d"
-  elsif OS.linux?
-    url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.19.0/vendir-linux-amd64"
-    sha256 "7f4634715be0219c779a0620f4aabd79a178a733bf29ef87428e758391aef148"
   end
 
-  depends_on :arch => :x86_64
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.19.0/vendir-linux-arm64"
+      sha256 "5856c2b7701bb41eb02eb8cd23ddeab142d2571dc001bb05adffc469429b3831"
+    else
+      url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.19.0/vendir-linux-amd64"
+      sha256 "7f4634715be0219c779a0620f4aabd79a178a733bf29ef87428e758391aef148"
+    end
+  end
 
   def install
     bin.install stable.url.split("/")[-1] => "vendir"


### PR DESCRIPTION
This change updates the kapp and vendir formulas with their linux arm64 variants.
