### PR TITLE
Update vendir to 0.21.1

### DIFF
--- a/vendir.rb
+++ b/vendir.rb
@@ -1,20 +1,20 @@
 class Vendir < Formula
   desc "Declaratively state what should be in a directory"
   homepage "https://carvel.dev/vendir"
-  version "v0.19.0"
+  version "v0.21.0"
 
   on_macos do
-    url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.19.0/vendir-darwin-amd64"
-    sha256 "81c11620d97ff05ab37036bb1761ef0faff403a3380ea87a1152ec36508e698d"
+    url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.21.0/vendir-darwin-amd64"
+    sha256 "eac9cec8750e88e42369c98b4c82fb406e48c7856aee2f3cc810f4b77f203baf"
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.19.0/vendir-linux-arm64"
-      sha256 "5856c2b7701bb41eb02eb8cd23ddeab142d2571dc001bb05adffc469429b3831"
+      url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.21.0/vendir-linux-arm64"
+      sha256 "f2559f0e870d625a7b1c0f9a5edd863b9f20f9c071811553f8e180fba0e933d2"
     else
-      url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.19.0/vendir-linux-amd64"
-      sha256 "7f4634715be0219c779a0620f4aabd79a178a733bf29ef87428e758391aef148"
+      url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.21.0/vendir-linux-amd64"
+      sha256 "e665435ead4335ba15baf604e9218fff39aa813cc2c9d181c7f379309aa98b45"
     end
   end
 

--- a/vendir.rb
+++ b/vendir.rb
@@ -1,20 +1,20 @@
 class Vendir < Formula
   desc "Declaratively state what should be in a directory"
   homepage "https://carvel.dev/vendir"
-  version "v0.21.0"
+  version "v0.21.1"
 
   on_macos do
-    url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.21.0/vendir-darwin-amd64"
-    sha256 "eac9cec8750e88e42369c98b4c82fb406e48c7856aee2f3cc810f4b77f203baf"
+    url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.21.1/vendir-darwin-amd64"
+    sha256 "579d661291f669a4f618c602e48d456693762e2ba23d4d8b64d12ceea05dd2cd"
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.21.0/vendir-linux-arm64"
-      sha256 "f2559f0e870d625a7b1c0f9a5edd863b9f20f9c071811553f8e180fba0e933d2"
+      url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.21.1/vendir-linux-arm64"
+      sha256 "4e56b51db9d8eabc0f947a0f0f6e3699248a4f1e1522df785e3de894294bdaa0"
     else
-      url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.21.0/vendir-linux-amd64"
-      sha256 "e665435ead4335ba15baf604e9218fff39aa813cc2c9d181c7f379309aa98b45"
+      url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.21.1/vendir-linux-amd64"
+      sha256 "7d9ffd06a888bf13e16ad964d7a0d0f6b7c23e8cad9774084c563cda81b91184"
     end
   end
 


### PR DESCRIPTION
Vendir 0.21.1 was released yesterday, but homebrew was not updated

Fixes: https://github.com/vmware-tanzu/homebrew-carvel/issues/13